### PR TITLE
Perlin noise fixes and gaussian efficiency

### DIFF
--- a/voxynth/noise.py
+++ b/voxynth/noise.py
@@ -7,7 +7,7 @@ from torch import Tensor
 from .filter import gaussian_blur
 
 
-def perlin(shape, smoothing, magnitude, device=None):
+def perlin(shape, smoothing, magnitude=1.0, device=None):
     """
     Generates a perlin noise image.
 


### PR DESCRIPTION
Hi @ahoopes 

Here are a few suggested changes I made while playing around. Feel free to pick and choose as you like:

1. You added a new `magnitude` parameter to the `perlin` function, but didn't update several calls to it. Instead of add a particular value of `magnitude` to the calls, I just added a default value of `1.0` to the function definition, which seems natural and fixes all the broken calls.
2. I was having several issues with the padding in the conv operation as part of the gaussian smoothing (it seems that padding will fail if the padding is bigger than the original image, which seems stupid but there you are, and sometimes this was happening when randomly drawn wavelengths were big enough). Instead of fix the padding, I just switched to using `padding="same"` in the call to conv and let it handle it. This fixes the issue and seems neater. But maybe I am missing something about why the padding was explicitly added in the first place?
3. Constructing the gaussian kernel is somewhat expensive, but we only do it in 1D. I created a new function to create a 1D gaussian vector and then re-use it if wavelengths are the same in all directions. This seems to speed up smoothing somewhat.  