### PR TITLE
Fix resizing

### DIFF
--- a/voxynth/augment.py
+++ b/voxynth/augment.py
@@ -282,10 +282,10 @@ def image_augment(
                     vsa = np.full(ndim, 1.0, dtype=np.float32)
                     ind = np.random.randint(ndim)
                     if voxsize[ind] < resized_max_voxsize:
-                        vsa[ind] = np.random.uniform(voxsize[ind], resized_max_voxsize)
+                        vsa[ind] = np.random.uniform(voxsize[ind].cpu(), resized_max_voxsize)
                     scale = tuple(1 / vsa)
                 else:
-                    scale = tuple(1 / np.random.uniform(voxsize, resized_max_voxsize))
+                    scale = tuple(1 / np.random.uniform(voxsize.cpu(), resized_max_voxsize))
                 # downsample then resample, always use nearest here because if we don't enable align_corners,
                 # then the image will be moved around a lot
                 linear = 'trilinear' if ndim == 3 else 'bilinear'

--- a/voxynth/augment.py
+++ b/voxynth/augment.py
@@ -289,8 +289,18 @@ def image_augment(
                 # downsample then resample, always use nearest here because if we don't enable align_corners,
                 # then the image will be moved around a lot
                 linear = 'trilinear' if ndim == 3 else 'bilinear'
-                ds = torch.nn.functional.interpolate(cimg.unsqueeze(0).unsqueeze(0), scale_factor=scale, mode=linear, align_corners=True)
-                cimg = torch.nn.functional.interpolate(ds, shape, mode=linear, align_corners=True).squeeze(0)
+                ds = torch.nn.functional.interpolate(
+                    cimg.unsqueeze(0).unsqueeze(0),
+                    scale_factor=scale,
+                    mode=linear,
+                    align_corners=True,
+                )
+                cimg = torch.nn.functional.interpolate(
+                    ds,
+                    shape,
+                    mode=linear,
+                    align_corners=True,
+                ).squeeze(0).squeeze(0)
 
         # ---- gamma exponentiation ----
 


### PR DESCRIPTION
Currently the resizing (i.e. random downsampling) operations are not working for me when I pass images with a channel dimension (as specified in the docstring and as seems to work fine for the other augmentations). They are failing due to a dimension mismatch. Also the logic for the downsampling down a single axis seems wrong: the scale factor should be '1' for the non-downsampled axes but that is not the case.

There's some small chance I'm missing something perhaps but I think the changes are needed to restore the expected functionality.  I also added a check on the `voxsize` parameter as this can cause confusing error messages if the user gets it wrong.

@adalca @ahoopes 